### PR TITLE
Add CSVResponseView

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,3 +2,6 @@
 
 # install local ipyrest package
 pip install -e .
+
+# install JupyterLab extensions
+jupyter labextension install qgrid

--- a/ipyrest/responseviews.py
+++ b/ipyrest/responseviews.py
@@ -18,6 +18,7 @@ import ipyleaflet
 import pandas as pd
 from ipywidgets import (Widget, HBox, VBox, Text, Textarea,
                         Button, Layout, Tab, Image, HTML)
+from qgrid import QGridWidget
 
 
 # Bounding box functions related to GeoJSONResponseView
@@ -188,6 +189,23 @@ class JSONResponseView(ResponseView):
         num_lines = value.count('\n')
         ta.rows = min(10, num_lines + 1)
         return ta
+
+
+class CSVResponseView(ResponseView):
+    """
+    A view that renders CSV data as an interactive table
+    """
+    name = 'CSV'
+    mimetype_pats = ['text/csv']
+
+    def render(self, resp: requests.models.Response) -> QGridWidget:
+        "Return an interactive grid with the CSV data"
+
+        csv = io.StringIO(resp.text)
+        df = pd.read_csv(csv)
+        self.data = df
+        grid = QGridWidget(df=df)
+        return grid
 
 
 class GeoJSONResponseView(ResponseView):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ jinja2
 numpy
 pandas
 protobuf
+qgrid
 requests
 timeout_decorator
 typing


### PR DESCRIPTION
Using the `qgrid` widget: https://github.com/quantopian/qgrid

For JupyterLab, this requires installing the JL extension:

`jupyter labextension install qgrid`

![ipyrest-qgrid](https://user-images.githubusercontent.com/591645/48873384-dd432f80-eded-11e8-8a78-081fa9e3fae5.gif)
