### PR TITLE
Add jupyterlab-manager extension to render widgets

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -4,4 +4,5 @@
 pip install -e .
 
 # install JupyterLab extensions
+jupyter labextension install @jupyter-widgets/jupyterlab-manager
 jupyter labextension install qgrid


### PR DESCRIPTION
Install `@jupyter-widgets/jupyterlab-manager` to be able to render widgets in JupyterLab.