### PR TITLE
Enable classic notebook extension for qgrid

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -3,6 +3,9 @@
 # install local ipyrest package
 pip install -e .
 
+# enable notebook extensions
+jupyter nbextension enable --py --sys-prefix qgrid
+
 # install JupyterLab extensions
 jupyter labextension install @jupyter-widgets/jupyterlab-manager
 jupyter labextension install qgrid


### PR DESCRIPTION
To make qgrid work in the classic notebook.

Source: https://github.com/quantopian/qgrid#installation