### PR TITLE
Add jupyter-leaflet labextension

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -8,4 +8,5 @@ jupyter nbextension enable --py --sys-prefix qgrid
 
 # install JupyterLab extensions
 jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension install jupyter-leaflet
 jupyter labextension install qgrid


### PR DESCRIPTION
Add the `jupyter-leaflet` labextension so the examples also render in JupyterLab.

Ideally the JupyterLab extensions should be installed whenever the user installs `ipyrest`, or like for nbdime does it with `nbdime extensions --enable` (to be run manually by the user): https://nbdime.readthedocs.io/en/latest/extensions.html#installation